### PR TITLE
Shutdown monitor is introduced.

### DIFF
--- a/Greentube.Monitoring.sln
+++ b/Greentube.Monitoring.sln
@@ -38,6 +38,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Greentube.Monitoring.Apache
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Greentube.Monitoring.Apache.NMS.ActiveMq.Tests", "test\Greentube.Monitoring.Apache.NMS.ActiveMq.Tests\Greentube.Monitoring.Apache.NMS.ActiveMq.Tests.csproj", "{DA5A72B9-EEED-4CFF-97A4-C5FE6BC90FB6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Greentube.Monitoring.IntegrationTests", "test\Greentube.Monitoring.IntegrationTests\Greentube.Monitoring.IntegrationTests.csproj", "{B9FAE3D9-FB45-479B-ADAE-5A81B0EED0A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Coverage|Any CPU = Coverage|Any CPU
@@ -117,6 +119,12 @@ Global
 		{DA5A72B9-EEED-4CFF-97A4-C5FE6BC90FB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA5A72B9-EEED-4CFF-97A4-C5FE6BC90FB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA5A72B9-EEED-4CFF-97A4-C5FE6BC90FB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9FAE3D9-FB45-479B-ADAE-5A81B0EED0A8}.Coverage|Any CPU.ActiveCfg = Coverage|Any CPU
+		{B9FAE3D9-FB45-479B-ADAE-5A81B0EED0A8}.Coverage|Any CPU.Build.0 = Coverage|Any CPU
+		{B9FAE3D9-FB45-479B-ADAE-5A81B0EED0A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9FAE3D9-FB45-479B-ADAE-5A81B0EED0A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9FAE3D9-FB45-479B-ADAE-5A81B0EED0A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9FAE3D9-FB45-479B-ADAE-5A81B0EED0A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -134,5 +142,6 @@ Global
 		{C87AE9B3-AEF3-4989-B6E6-DDE0CE181C40} = {AE749C50-94C1-445C-B13F-E9D19372CBDB}
 		{D5DEE9C7-0A0A-4789-BD75-F78F5037C69A} = {843C8ED0-4792-40E0-8903-A3E5FF74A0A3}
 		{DA5A72B9-EEED-4CFF-97A4-C5FE6BC90FB6} = {AE749C50-94C1-445C-B13F-E9D19372CBDB}
+		{B9FAE3D9-FB45-479B-ADAE-5A81B0EED0A8} = {AE749C50-94C1-445C-B13F-E9D19372CBDB}
 	EndGlobalSection
 EndGlobal

--- a/src/Greentube.Monitoring/DependencyInjection/MonitoringServiceCollectionExtensions.cs
+++ b/src/Greentube.Monitoring/DependencyInjection/MonitoringServiceCollectionExtensions.cs
@@ -30,6 +30,8 @@ namespace Microsoft.AspNetCore.Builder
             Assembly entryAssembly,
             Action<MonitoringOptions> optionsAction = null)
         {
+            services.AddSingleton<IShutdownStatusProvider>(new ShutdownStatusProvider());
+
             var options = new MonitoringOptions();
             optionsAction?.Invoke(options);
 

--- a/src/Greentube.Monitoring/DependencyInjection/ShutdownMonitoringExtensions.cs
+++ b/src/Greentube.Monitoring/DependencyInjection/ShutdownMonitoringExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Greentube.Monitoring.DependencyInjection
+{
+    public static class ShutdownMonitoringExtensions
+    {
+        /// <summary>
+        /// Adds the Shutdown monitor.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <param name="resourceName">Name of the resource. Defaults to: Uri.AbsoluteUri.</param>
+        /// <param name="configOverride">The configuration override.</param>
+        public static void AddShutdownMonitor(
+            this MonitoringOptions options,
+
+            string resourceName = null,
+            IResourceMonitorConfiguration configOverride = null)
+        {
+            options.AddResourceMonitor((conf, provider) =>
+            {
+                var logger = provider.GetRequiredService<ILogger<ShutdownMonitor>>();
+                return new ShutdownMonitor(
+                    resourceName ?? "shutdown",
+                    provider.GetRequiredService<IShutdownStatusProvider>(),
+                    configOverride ?? conf,
+                    logger
+                );
+            });
+        }
+    }
+}

--- a/src/Greentube.Monitoring/IShutdownStatusProvider.cs
+++ b/src/Greentube.Monitoring/IShutdownStatusProvider.cs
@@ -1,0 +1,18 @@
+﻿namespace Greentube.Monitoring
+{
+    /// <summary>
+    /// Resolve this inteface on application shutdown to inform the loab balancer that it should take down the node.
+    /// </summary>
+    public interface IShutdownStatusProvider
+    {
+        /// <summary>
+        /// Current status of Shutdown process
+        /// </summary>
+        bool IsShuttingDown { get; }
+
+        /// <summary>
+        /// Inform Resource monitor that application is shutting down
+        /// </summary>
+        void Shutdown();
+    }
+}

--- a/src/Greentube.Monitoring/ShutdownHealthCheckStrategy.cs
+++ b/src/Greentube.Monitoring/ShutdownHealthCheckStrategy.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Greentube.Monitoring
+{
+    internal sealed class ShutdownHealthCheckStrategy : IHealthCheckStrategy
+    {
+        private readonly IShutdownStatusProvider _shutdownStatusProvider;
+
+        public ShutdownHealthCheckStrategy(IShutdownStatusProvider shutdownStatusProvider)
+        {
+            _shutdownStatusProvider = shutdownStatusProvider;
+        }
+
+        public Task<bool> Check(CancellationToken token)
+        {
+            return Task.FromResult(!_shutdownStatusProvider.IsShuttingDown);
+        }
+    }
+}

--- a/src/Greentube.Monitoring/ShutdownResourceMonitor.cs
+++ b/src/Greentube.Monitoring/ShutdownResourceMonitor.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Greentube.Monitoring
+{
+    /// <summary>
+    /// The Critical Monitor
+    /// Usage: forcibly tell LoadBalancer to return {"Up":false} when application shutdowns to provide the graceful shutdown
+    /// </summary>
+    internal sealed class ShutdownMonitor : ResourceMonitor
+    {
+        public ShutdownMonitor(string resourceName, IShutdownStatusProvider shutdownStatusProvider, IResourceMonitorConfiguration configuration, ILogger<ResourceMonitor> logger) : base(resourceName, new ShutdownHealthCheckStrategy(shutdownStatusProvider), configuration, logger, true)
+        {
+        }
+    }
+}

--- a/src/Greentube.Monitoring/ShutdownStatusProvider.cs
+++ b/src/Greentube.Monitoring/ShutdownStatusProvider.cs
@@ -1,0 +1,17 @@
+﻿namespace Greentube.Monitoring
+{
+    internal sealed class ShutdownStatusProvider : IShutdownStatusProvider
+    {
+        public ShutdownStatusProvider()
+        {
+            IsShuttingDown = false;
+        }
+
+        public bool IsShuttingDown { get; private set; }
+
+        public void Shutdown()
+        {
+            IsShuttingDown = true;
+        }
+    }
+}

--- a/test/Greentube.Monitoring.IntegrationTests/Greentube.Monitoring.IntegrationTests.csproj
+++ b/test/Greentube.Monitoring.IntegrationTests/Greentube.Monitoring.IntegrationTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <AssemblyName>Greentube.Monitoring.IntegrationTests</AssemblyName>
+    <PackageId>Greentube.Monitoring.IntegrationsTests</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Greentube.Monitoring.AspNetCore\Greentube.Monitoring.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Greentube.Monitoring\Greentube.Monitoring.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Greentube.Monitoring.IntegrationTests/Greentube.Monitoring.IntegrationTests.csproj
+++ b/test/Greentube.Monitoring.IntegrationTests/Greentube.Monitoring.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Greentube.Monitoring.IntegrationTests</AssemblyName>
     <PackageId>Greentube.Monitoring.IntegrationsTests</PackageId>

--- a/test/Greentube.Monitoring.IntegrationTests/ShutdownMonitorTests.cs
+++ b/test/Greentube.Monitoring.IntegrationTests/ShutdownMonitorTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Greentube.Monitoring.IntegrationTests
+{
+    public class ShutdownMonitorTests
+    {
+        private readonly TestServer _server;
+
+        public ShutdownMonitorTests()
+        {
+            var webHostBuilder = new WebHostBuilder();
+            _server = new TestServer(webHostBuilder.UseStartup<TestStartup>());
+        }
+
+        [Fact]
+        public async Task Shutdown_Causes_IsNodeDown()
+        {
+            var client = _server.CreateClient();
+
+            // check if node is up
+            var httpResponseMessage = await client.GetAsync("/health");
+            var healthCheckResponse = JsonConvert.DeserializeObject<HealthCheckResponse>(await httpResponseMessage.Content.ReadAsStringAsync());
+            Assert.True(healthCheckResponse.Up);
+
+            // bring down the monitor
+            _server.Host.Services.GetRequiredService<IShutdownStatusProvider>().Shutdown();
+
+            // wait to pick up changes
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
+            
+            // check if node is down
+            httpResponseMessage = await client.GetAsync("/health");
+            healthCheckResponse = JsonConvert.DeserializeObject<HealthCheckResponse>(await httpResponseMessage.Content.ReadAsStringAsync());
+            Assert.False(healthCheckResponse.Up);
+
+        }
+
+        private class HealthCheckResponse
+        {
+            public bool Up { get; set; }
+        }
+    }
+}

--- a/test/Greentube.Monitoring.IntegrationTests/TestStartup.cs
+++ b/test/Greentube.Monitoring.IntegrationTests/TestStartup.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Reflection;
+using Greentube.Monitoring.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Greentube.Monitoring.IntegrationTests
+{
+    public sealed class TestStartup
+    {
+        public IServiceProvider ConfigureServices(IServiceCollection services)
+        {
+            services.AddMonitoring(Assembly.GetEntryAssembly(), options =>
+            {
+                options.AddShutdownMonitor(configOverride:new ResourceMonitorConfiguration(true, TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(100)));
+            });
+            return services.BuildServiceProvider();
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseMonitoringEndpoint(options => options.Path = "/health");
+        }
+    }
+}


### PR DESCRIPTION
The purpose: forcibly set up the flag that loadbalancer can take down the node during graceful degradation